### PR TITLE
Add Ruby 2.3.3 build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.0.0
   - 2.1.2
   - 2.2.3
+  - 2.3.3
   - jruby-18mode
   - jruby-19mode
   - ree


### PR DESCRIPTION
I simply added a line to the config to make sure the gem is compatible to ruby 2.3